### PR TITLE
Fix import of definitions.py

### DIFF
--- a/museek/config/test_calibrator_extract.py
+++ b/museek/config/test_calibrator_extract.py
@@ -1,6 +1,6 @@
 import os
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.utils.config_section import ConfigSection
 
 Pipeline = ConfigSection(

--- a/museek/config/test_calibrator_flagging.py
+++ b/museek/config/test_calibrator_flagging.py
@@ -1,6 +1,6 @@
 import os
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.utils.config_section import ConfigSection
 
 Pipeline = ConfigSection(

--- a/museek/plugin/aoflagger_cross_plugin.py
+++ b/museek/plugin/aoflagger_cross_plugin.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from matplotlib import pyplot as plt
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.plugin.abstract_parallel_joblib_plugin import AbstractParallelJoblibPlugin
 from ivory.utils.requirement import Requirement
 from ivory.utils.result import Result

--- a/museek/plugin/aoflagger_postcalibration_plugin.py
+++ b/museek/plugin/aoflagger_postcalibration_plugin.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from matplotlib import pyplot as plt
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.plugin.abstract_parallel_joblib_plugin import AbstractParallelJoblibPlugin
 from ivory.utils.requirement import Requirement
 from ivory.utils.result import Result

--- a/museek/plugin/aoflagger_secondrun_plugin.py
+++ b/museek/plugin/aoflagger_secondrun_plugin.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from matplotlib import pyplot as plt
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.plugin.abstract_parallel_joblib_plugin import AbstractParallelJoblibPlugin
 from ivory.utils.requirement import Requirement
 from ivory.utils.result import Result

--- a/museek/plugin/aoflagger_tracking_plugin.py
+++ b/museek/plugin/aoflagger_tracking_plugin.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from matplotlib import pyplot as plt
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.plugin.abstract_parallel_joblib_plugin import AbstractParallelJoblibPlugin
 from ivory.utils.requirement import Requirement
 from ivory.utils.result import Result

--- a/museek/plugin/gain_calibration_plugin.py
+++ b/museek/plugin/gain_calibration_plugin.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 from matplotlib import pyplot as plt
 
-from definitions import ROOT_DIR
+from museek.definitions import ROOT_DIR
 from ivory.plugin.abstract_plugin import AbstractPlugin
 from ivory.plugin.abstract_parallel_joblib_plugin import AbstractParallelJoblibPlugin
 from ivory.utils.requirement import Requirement


### PR DESCRIPTION
Some of the modules from gain-calibration branch did not have this fix when it was merged into main.