### PR TITLE
Pin ivory to version with numpy<2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "sphinx",
     "matplotlib",
     "papermill",
-    "ivory @ git+https://github.com/meerklass/ivory.git",
+    "ivory @ git+https://github.com/meerklass/ivory.git@v1.0.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ ipykernel
 pysm3
 sphinx
 papermill
-git+https://github.com/meerklass/ivory.git@1.0.0
+git+https://github.com/meerklass/ivory.git@v1.0.0


### PR DESCRIPTION
Pin ivory to version 1.0.0, which use numpy<2.0.0, until museek is updated to numpy>2.0.0