### PR TITLE
Pin ivory version back to v2.0.0 for Numpy2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pysm3",
     "matplotlib",
     "papermill",
-    "ivory @ git+https://github.com/meerklass/ivory.git@v1.0.0",
+    "ivory @ git+https://github.com/meerklass/ivory.git@v2.0.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Need ivory v2.0.0 or higher for Numpy2.