### PR TITLE
Update cache location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update the codes in `gain_calibration_plugin` and `aoflagger_postcalibration_plugin`:
   * fix the bug in mask saving, using a dictionary to save the mask for calibrated data
     save gain in the results
-
   * add do_delete_auto_data to decide whether save the raw data and flags in pickles after calibration
   * add new_output_path in aoflagger_postcalibration_plugin, then we can change the output path if needed
   * update the config file process_uhf_band.py, reorder the configsection
+* Implement intelligent cache directory fallback logic for multi-user cluster deployments
+  * Three-tier priority: ROOT_DIR/cache (if writable) → MUSEEK_CACHE_DIR env var → XDG_CACHE_HOME/museek
+  * Automatically creates cache directory on first data access
+  * Supports centralized MuSEEK installations with per-user cache isolation
+  * Refactored path operations from os module to pathlib for consistency
+  * Added logging output to display cache directory location when data is loaded
 
 ## [0.5.0] - 2026-02-03
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,31 @@ EXAMPLES:
 
 To access results stored by the pipeline as `pickle` files, the class `ContextLoader` can be used.
 
+### Cache Directory Configuration
+
+MuSEEK can store cached visibility, flags, and weights extracted from the raw correlator data as `npz` files to speed up the read of these data in the later steps of the pipeline.
+
+The cache directory is determined using the following three-tier priority:
+
+1. **ROOT_DIR/cache**: Uses the cache directory inside the local package installation if it is writable. This is the default for a dedicated single-user installations.
+2. **MUSEEK_CACHE_DIR environment variable**: If set, MuSEEK will use the directory specified by this environment variable.
+   ```bash
+   export MUSEEK_CACHE_DIR=/scratch/my_cache
+   museek museek.config.process_uhf_band
+   ```
+3. **XDG_CACHE_HOME/museek** (default fallback): If the above options are not available, MuSEEK will use `~/.cache/museek` (or the directory specified by `XDG_CACHE_HOME` environment variable if set). This ensures each user has their own isolated cache directory, preventing permission conflicts on shared systems.
+
+### Automatic Cache Directory Creation
+
+The cache directory is automatically created (with parent directories) when `TimeOrderedData` is first instantiated, typically during the initial data loading stage. When data caching is enabled and the cache directory is being used for the first time, MuSEEK will log:
+
+```
+Using cache directory: /path/to/cache
+Creating cache file for <block_name>...
+```
+
+This logging only appears when data processing actually involves visibility caching (i.e., not for demonstration or non-data pipelines).
+
 ## Anatomy of Pipeline and Plugins
 
 ### Configuration File

--- a/museek/config/test_io.py
+++ b/museek/config/test_io.py
@@ -1,0 +1,24 @@
+"""Pipeline config for testing museek I/O."""
+
+from ivory.utils.config_section import ConfigSection
+
+CONTEXT_FOLDER = "./context"
+DATA_FOLDER = "/idia/raw/meerklass/SCI-20230907-MS-01"
+
+Pipeline = ConfigSection(
+    plugins=[
+        "museek.plugin.in_plugin",
+    ],
+)
+
+InPlugin = ConfigSection(
+    block_name="1716154890",
+    token=None,  # Not loading from token
+    receiver_list=None,  # Use all available receivers
+    data_folder=DATA_FOLDER,
+    force_load_auto_from_correlator_data=True,  # Don't use local "cache"
+    force_load_cross_from_correlator_data=True,  # Don't use local "cache"
+    do_save_visibility_to_disc=True,  # Extract and save visibilities, flags and weights
+    do_store_context=True,
+    context_folder=CONTEXT_FOLDER,  # Directory to store results
+)

--- a/museek/definitions.py
+++ b/museek/definitions.py
@@ -1,11 +1,38 @@
 import os
+from pathlib import Path
 
-ROOT_DIR = os.path.dirname(
-    os.path.dirname(os.path.abspath(__file__))
-)  # This is your Project Root
+ROOT_DIR = str(Path(__file__).resolve().parent.parent)  # This is your Project Root
 KILO = 1e3
 MEGA = 1e6
 GIGA = 1e9
 
 SPEED_OF_LIGHT = 3e8  # m/s
 SECONDS_IN_ONE_DAY = 86400  # s
+
+
+def get_cache_dir() -> str:
+    """Determine the cache directory with fallback logic.
+
+    Priority:
+    1. If ROOT_DIR is writable by user, use ROOT_DIR/cache
+    2. If MUSEEK_CACHE_DIR env var exists, use it
+    3. Otherwise, use XDG cache directory: $XDG_CACHE_HOME/museek or ~/.cache/museek
+
+    Returns:
+        str: Path to the cache directory
+
+    """
+    root_path = Path(ROOT_DIR)
+
+    # Check if ROOT_DIR is writable
+    if os.access(root_path, os.W_OK):
+        cache_dir = root_path / "cache"
+    # Check if MUSEEK_CACHE_DIR environment variable is set
+    elif "MUSEEK_CACHE_DIR" in os.environ:
+        cache_dir = Path(os.environ["MUSEEK_CACHE_DIR"])
+    # Fall back to XDG cache directory
+    else:
+        xdg_cache_home = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+        cache_dir = xdg_cache_home / "museek"
+
+    return str(cache_dir)

--- a/museek/time_ordered_data.py
+++ b/museek/time_ordered_data.py
@@ -1,6 +1,7 @@
 import os
 from copy import copy
 from datetime import datetime
+from pathlib import Path
 from typing import Any, NamedTuple
 
 import katdal
@@ -10,7 +11,7 @@ from katdal.lazy_indexer import DaskLazyIndexer
 from katpoint import Antenna, Target
 
 from museek.data_element import DataElement
-from museek.definitions import ROOT_DIR
+from museek.definitions import get_cache_dir
 from museek.enums.scan_state_enum import ScanStateEnum
 from museek.factory.data_element_factory import (
     AbstractDataElementFactory,
@@ -99,17 +100,16 @@ class TimeOrderedData:
         self.all_antennas = data.ants
         self._auto_select(data=data)
         self._data_str = str(data)
-        self._auto_cache_file_name = f"{data.name}_auto_visibility_flags_weights.npz"
-        self._cross_cache_file_name = f"{data.name}_cross_visibility_flags_weights.npz"
-        cache_file_directory = os.path.join(ROOT_DIR, "cache")
-        os.makedirs(cache_file_directory, exist_ok=True)
-        self._auto_cache_file = os.path.join(
-            cache_file_directory, self._auto_cache_file_name
-        )
-        self._cross_cache_file = os.path.join(
-            cache_file_directory, self._cross_cache_file_name
-        )
-
+        # Cache data directory and filenames
+        self.cache_file_directory = Path(get_cache_dir()).resolve()
+        self.cache_file_directory.mkdir(parents=True, exist_ok=True)
+        self._auto_cache_file = (
+            self.cache_file_directory / f"{data.name}_auto_visibility_flags_weights.npz"
+        ).as_posix()
+        self._cross_cache_file = (
+            self.cache_file_directory
+            / f"{data.name}_cross_visibility_flags_weights.npz"
+        ).as_posix()
         self.obs_script_log = data.obs_script_log
         self.shape = data.shape
         self.name = data.name
@@ -576,6 +576,7 @@ class TimeOrderedData:
                 f"cannot store visibility, flag and weight data to cache file."
             )
         print(f"Creating cache file for {self.name}...")
+        print(f"Using cache directory: {self.cache_file_directory}")
         np.savez_compressed(
             cache_file,
             visibility=visibility,


### PR DESCRIPTION
This PR fixes #192 by introducing a deterministic cache directory logic with fallback.

1. If ROOT_DIR is writable by user, use ROOT_DIR/cache (previous behavior but with write access check)
2. If MUSEEK_CACHE_DIR environment variable is set to a directory, use it as a cache directory
3. Otherwise, use XDG cache directory: $XDG_CACHE_HOME/museek or fallback to ~/.cache/museek

This will allow multiple users run museek using the same shared read-only installation as the cache folder is user-dependent.