### PR TITLE
Track version in slurm log

### DIFF
--- a/museek/cli/run_process_uhf_band.py
+++ b/museek/cli/run_process_uhf_band.py
@@ -36,9 +36,9 @@ def generate_sbatch_script(
     default_slurm_options = [
         f"--job-name=MuSEEK-Process-UHF-{block_name}",
         "--ntasks=1",
-        "--cpus-per-task=24",
-        "--mem=200G",
-        "--time=36:00:00",
+        "--cpus-per-task=16",
+        "--mem=220G",
+        "--time=20:00:00",
         f"--output=slurm-museek-process-uhf-{block_name}-%j.log",
     ]
 
@@ -118,7 +118,7 @@ def main(
       Job name:       MuSEEK-Process-UHF-<block_name>
       Tasks:          1
       CPUs per task:  24
-      Memory:         200GB
+      Memory:         220GB
       Max time:       36 hours
       Log output:     museek-process-uhf-<block_name>.log
 

--- a/museek/cli/slurm_utils.py
+++ b/museek/cli/slurm_utils.py
@@ -136,7 +136,9 @@ def build_sbatch_script(
             "# Activate Python virtual environment",
             f"source {venv_path}/bin/activate",
             'echo "Python executable is: $(which python)"',
+            'echo "Python version: $(python --version)"',
             "echo \"MuSEEK version: $(python -c 'import museek; print(museek.__version__)')\"",
+            "echo \"Ivory version:  $(python -c 'import ivory; print(ivory.__version__)')\"",
             "",
         ]
     )


### PR DESCRIPTION
* `museek_run_process_uhf` now print Python, MuSEEK and Ivory versions in SLURM log 
* Update default resource allocation in `museek_run_process_uhf` to 16 CPUs, 220G mem and 20 hours time