### PR TITLE
Process uhf defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Base paths (e.g., `/path/to/output`) are appended with `/<block_name>/`
   * Complete paths (e.g., `/path/to/output/<block_name>/context`) are used as-is
   * Provides flexible configuration for both relative and absolute paths
+* `museek_run_process_uhf` now print Python, MuSEEK and Ivory versions in SLURM log 
 
 ### Changed
 
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Fixed bug in mask saving, using a dictionary to save the mask for calibrated data and save gain in the results
   * Added `do_delete_auto_data` to decide whether to save the raw data and flags in pickles after calibration
   * Reordered config sections in `process_uhf_band.py`
+* Update default resource allocation in `museek_run_process_uhf` to 16 CPUs, 220G mem and 20 hours time
 
 ### Fixed
 

--- a/museek/cli/run_notebook.py
+++ b/museek/cli/run_notebook.py
@@ -292,8 +292,8 @@ def generate_sbatch_script(
     default_slurm_options = [
         f"--job-name='MuSEEK-Notebook-{block_name}'",
         "--ntasks=1",
-        "--cpus-per-task=32",
-        "--mem=248GB",
+        "--cpus-per-task=16",
+        "--mem=220GB",
         "--time=01:00:00",
         f"--output=slurm-{Path(notebook_name).stem}-{block_name}-%j.out",
     ]
@@ -306,7 +306,7 @@ def generate_sbatch_script(
         'echo "=========================================="',
         'echo "Executing MuSEEK Notebook"',
         'echo "=========================================="',
-        f'echo "Notebook:      "{notebook_path}""',
+        f'echo "Notebook template:      "{notebook_path}""',
         f'echo "Block name:    {block_name}"',
         f'echo "Box:           {box}"',
         f'echo "Kernel:        {kernel}"',
@@ -366,14 +366,14 @@ def generate_sbatch_script(
 @add_box_option()
 @click.option(
     "-d",
-    "--data-path",
+    "--base-data-path",
     type=click.Path(
         file_okay=False, dir_okay=True, writable=True, path_type=Path, resolve_path=True
     ),
-    default="/idia/projects/meerklass/MEERKLASS-1/uhf_data/XLP2025/pipeline",
+    default="/idia/projects/meerklass/MEERKLASS-1/museek/latest_runs",
     help=(
-        "Base path of the data for the notebook. Same as `data_path` parameter in "
-        "calibrated_data_check*.ipynb notebooks."
+        "Base path of the requied data for the notebook. The notebook will search for "
+        "pickle files in <base-data-path>/box<box>/<block-name>/"
     ),
     show_default=True,
 )
@@ -386,7 +386,7 @@ def generate_sbatch_script(
     default=None,
     help=(
         "Directory for notebook output. If not specify, output will be saved to "
-        "<data-path>/BOX<box>/<block-name>/"
+        "<base-data-path>/box<box>/<block-name>/"
     ),
     show_default=True,
 )
@@ -416,7 +416,7 @@ def main(
     notebook: str,
     block_name: str,
     box: str,
-    data_path: Path,
+    base_data_path: Path,
     output_dir: Path | None,
     venv: Path,
     kernel: str | None,
@@ -447,10 +447,10 @@ def main(
       # Dry run to show the generated sbatch script without submitting:
       museek_run_notebook --notebook calibrated_data_check-postcali \\
         --block-name 1708972386 --box 6 --dry-run
-      # Passing additional parameters to the notebook (e.g., data_path):
+      # Passing additional parameters to the notebook:
       museek_run_notebook --notebook calibrated_data_check-postcali \\
-        --block-name 1708972386 --box 6 --parameters data_path \\
-        /custom/path/
+        --block-name 1708972386 --box 6 --parameters random_var \\
+        random_var_value
       # Passing additional SLURM options (e.g., email notification):
       museek_run_notebook --notebook calibrated_data_check-postcali \\
         --block-name 1708972386 --box 6 \\
@@ -464,10 +464,10 @@ def main(
     DEFAULT SLURM PARAMETERS:
       Job name:       MuSEEK-Notebook-<block_name>
       Tasks:          1
-      CPUs per task:  32
-      Memory:         248GB
+      CPUs per task:  16
+      Memory:         220GB
       Max time:       1 hour
-      Log output:     <notebook_name>-<block_name>.log
+      Log output:     slrum-<notebook_name>-<block_name>.log
 
     """
     # Validate notebook exists
@@ -476,9 +476,12 @@ def main(
     # Determine kernel (always, as detection is read-only with no side effects)
     kernel_to_use = determine_kernel(venv, kernel)
 
+    # Default data_path
+    data_path = base_data_path / f"box{box}" / block_name
+
     # Default output_dir based on data_path if not specified
     if output_dir is None:
-        output_dir = data_path / f"BOX{box}" / block_name
+        output_dir = data_path
         click.echo(f"Output directory not specified, using: {output_dir}")
 
     # Generate the sbatch script

--- a/museek/cli/run_process_uhf_band.py
+++ b/museek/cli/run_process_uhf_band.py
@@ -30,7 +30,7 @@ def generate_sbatch_script(
     slurm_options: list[str],
 ) -> str:
     """Generate the sbatch script content."""
-    context_folder = Path(base_context_folder) / f"box{box}" / block_name / "context"
+    context_folder = Path(base_context_folder) / f"box{box}" / block_name
 
     # Define default SLURM options
     default_slurm_options = [
@@ -80,8 +80,8 @@ def generate_sbatch_script(
     type=click.Path(
         file_okay=False, dir_okay=True, writable=True, path_type=Path, resolve_path=True
     ),
-    default="/idia/projects/meerklass/MEERKLASS-1/museek/XLP2025/pipeline",
-    help="Base directory for context/output. Final output: <base-context-folder>/box<box>/<block-name>/context",
+    default="/idia/projects/meerklass/MEERKLASS-1/museek/latest_runs",
+    help="Base directory for context outputs. Final output directory: <base-context-folder>/box<box>/<block-name>",
     show_default=True,
 )
 @click.option(
@@ -106,6 +106,8 @@ def main(
 ) -> None:
     """Generate and submit a Slurm job to process UHF band data using the MuSEEK pipeline.
 
+    This command should only be run on Ilifu.
+
     \b
     EXAMPLES:
       museek_run_process_uhf_band --block-name 1675632179 --box 6
@@ -117,16 +119,15 @@ def main(
     DEFAULT SLURM PARAMETERS:
       Job name:       MuSEEK-Process-UHF-<block_name>
       Tasks:          1
-      CPUs per task:  24
+      CPUs per task:  16
       Memory:         220GB
-      Max time:       36 hours
-      Log output:     museek-process-uhf-<block_name>.log
+      Max time:       20 hours
+      Log output:     slurm-museek-process-uhf-<block_name>-<job_id>.log
 
     \b
     REQUIREMENTS:
       - Access to Ilifu
       - meerklass-1 group permission for raw data access
-      - sbatch command available (Slurm)
     """
     # Generate the sbatch script
     script_content = generate_sbatch_script(


### PR DESCRIPTION
This PR updates defaults SLURM and path parameters of `museek_run_process_uhf` and `museek_run_notebook` command to reflect the new data organisation for 2026 observing season.